### PR TITLE
Update in README.md the proper env variable to set server pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Where the arguments are:
 Setup password:
 ```
 Unix Bash (Linux, Mac, etc.):
-$ export PASSWORD=hello
+$ export SECRET=hello
 
 Windows CMD:
-> set PASSWORD=hello
+> set SECRET=hello
 
 Windows PowerShell:
-> $env:PASSWORD = "hello"
+> $env:SECRET = "hello"
 ```
 
 `npm start`


### PR DESCRIPTION
I think the README.md needs to be updated in order to reflect proper env variable name used by the server.